### PR TITLE
修复在block中修改导航栏第二次进入导航栏按钮会变为主题色的bug

### DIFF
--- a/照片选择器/HXPhotoPicker/HXAlbumListViewController.m
+++ b/照片选择器/HXPhotoPicker/HXAlbumListViewController.m
@@ -177,6 +177,9 @@ UITableViewDelegate
             self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName : self.manager.configuration.navigationTitleColor};
         }
     }
+    if (self.manager.configuration.navigationBar) {
+        self.manager.configuration.navigationBar(self.navigationController.navigationBar, self);
+    }
 }
 - (void)configTableView {
     if (self.manager.configuration.singleSelected ||


### PR DESCRIPTION
修复在block中修改导航栏后退出选择器再进入导航栏按钮会变为主题色的bug