### PR TITLE
对于方向不是up的照片，编辑后会产生方向错乱的问题

### DIFF
--- a/Sources/HXPhotoPicker/Core/Util/TextManager.swift
+++ b/Sources/HXPhotoPicker/Core/Util/TextManager.swift
@@ -199,6 +199,7 @@ public extension HX.TextManager {
             public var iCloudSyncFailedHudTitle: TextType = .localized("iCloud同步失败")
             public var videoLoadFailedHudTitle: TextType = .localized("视频加载失败!")
             public var bottomView: BottomView = .init()
+            public var livePhotoTitle: TextType = .custom("Live")
         }
         
         public struct BottomView {

--- a/Sources/HXPhotoPicker/Editor+View/Util/EditorView+PhotoTools.swift
+++ b/Sources/HXPhotoPicker/Editor+View/Util/EditorView+PhotoTools.swift
@@ -97,7 +97,7 @@ extension PhotoTools {
         _ inputImage: UIImage?,
         cropFactor: EditorAdjusterView.CropFactor
     ) -> UIImage? {
-        guard let imageRef = inputImage?.cgImage else {
+        guard let inputImage = inputImage?.normalizedImage(), let imageRef = inputImage.cgImage else {
             return nil
         }
         if cropFactor.sizeRatio.equalTo(.init(x: 1, y: 1)),

--- a/Sources/HXPhotoPicker/Editor/Controller/EditorViewController+LoadAsset.swift
+++ b/Sources/HXPhotoPicker/Editor/Controller/EditorViewController+LoadAsset.swift
@@ -755,13 +755,7 @@ extension EditorViewController {
                     switch result {
                     case .success(let dataResult):
                         if AssetManager.assetDownloadFinined(for: dataResult.info) || AssetManager.assetCancelDownload(for: dataResult.info) {
-                            let image = {
-                                if asset.isHDRAsset {
-                                    return UIImage.HDRDecoded(dataResult.imageData)
-                                } else {
-                                    return UIImage(data: dataResult.imageData)
-                                }
-                            }()
+                            let image = UIImage(data: dataResult.imageData)
                             guard let image = image else {
                                 self.loadAssetStatus = .failure
                                 PhotoManager.HUDView.dismiss(delay: 0, animated: true, for: self.view)

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PreviewLivePhotoViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PreviewLivePhotoViewCell.swift
@@ -89,7 +89,7 @@ class PreviewLivePhotoViewCell: PhotoPreviewViewCell, PhotoPreviewContentViewDel
         imageView.x = 5
         liveMarkView.contentView.addSubview(imageView)
         let label = UILabel()
-        label.text = "Live"
+        label.text = .textManager.picker.preview.livePhotoTitle.text
         label.textColor = "#666666".color
         label.textAlignment = .center
         label.font = .regularPingFang(ofSize: 15)

--- a/Swift/Classes/Extension/UIImage+Extension.swift
+++ b/Swift/Classes/Extension/UIImage+Extension.swift
@@ -22,7 +22,7 @@ extension UIImage {
         return self.scaleToFillSize(size: imageSize)
     }
     func scaleToFillSize(size: CGSize) -> UIImage? {
-        if __CGSizeEqualToSize(self.size, size) {
+        if self.size == size {
             return self
         }
         let format = UIGraphicsImageRendererFormat()


### PR DESCRIPTION
1、编辑照片时是按照方向为up的画布去考虑的，对于方向不是up的图片来说，就产生编辑后图片方向错乱的问题了，这里先把方向修正为up再编辑
2、编辑暂不支持HDR，所以暂时先去掉编辑页面的HDR效果
3、LivePhoto预览界面，左上角标记增加文字配置textManager.picker.preview.livePhotoTitle.text，对齐imageResource.picker.preview.livePhoto.image

@SilenceLove 