### PR TITLE
修复LivePhoto与HDRPhoto可能会产生覆盖的问题

### DIFF
--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPeekViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPeekViewController.swift
@@ -45,8 +45,7 @@ public class PhotoPeekViewController: UIViewController {
         super.viewDidLoad()
         if photoAsset != nil {
             if photoAsset.mediaType == .photo {
-                if photoAsset.mediaSubType == .livePhoto ||
-                    photoAsset.mediaSubType == .localLivePhoto {
+                if photoAsset.mediaSubType.isLivePhoto {
                     contentView = PhotoPreviewContentLivePhotoView()
                 }else {
                     contentView = PhotoPreviewContentPhotoView()

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController+CollectionView.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController+CollectionView.swift
@@ -26,8 +26,7 @@ extension PhotoPreviewViewController: UICollectionViewDataSource {
         }
         let cell: PhotoPreviewViewCell
         if photoAsset.mediaType == .photo {
-            if photoAsset.mediaSubType == .livePhoto ||
-                photoAsset.mediaSubType == .localLivePhoto {
+            if photoAsset.mediaSubType.isLivePhoto {
                 cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: PreviewLivePhotoViewCell.className,
                     for: indexPath

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController+Toolbar.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController+Toolbar.swift
@@ -193,8 +193,7 @@ extension PhotoPreviewViewController: PhotoToolBarDelegate {
             ) else {
                 return
             }
-            if photoAsset.mediaSubType == .livePhoto ||
-               photoAsset.mediaSubType == .localLivePhoto {
+            if photoAsset.mediaSubType.isLivePhoto {
                 let cell = getCell(
                     for: currentPreviewIndex
                 )

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
@@ -129,8 +129,7 @@ public class PhotoPreviewViewController: PhotoBaseViewController {
     public override func deviceOrientationWillChanged(notify: Notification) {
         orientationDidChange = true
         if let cell = getCell(for: currentPreviewIndex) {
-            if cell.photoAsset.mediaSubType == .livePhoto ||
-                cell.photoAsset.mediaSubType == .localLivePhoto {
+            if cell.photoAsset.mediaSubType.isLivePhoto {
                 if #available(iOS 9.1, *) {
                     cell.scrollContentView.livePhotoView.stopPlayback()
                 }

--- a/Sources/HXPhotoPicker/Picker/Extension/Picker+Array.swift
+++ b/Sources/HXPhotoPicker/Picker/Extension/Picker+Array.swift
@@ -200,9 +200,7 @@ public extension Array where Element: PhotoAsset {
                         mediatype = .video
                     }
                     #if HXPICKER_ENABLE_EDITOR
-                    if (photoAsset.mediaSubType == .livePhoto ||
-                        photoAsset.mediaSubType == .localLivePhoto) &&
-                        photoAsset.editedResult != nil {
+                    if photoAsset.mediaSubType.isLivePhoto && photoAsset.editedResult != nil {
                         mediatype = .photo
                     }
                     #endif
@@ -223,8 +221,7 @@ public extension Array where Element: PhotoAsset {
                         toVideoURL = fileConfig.videoURL
                     }
                     if mediatype == .photo {
-                        if photoAsset.mediaSubType == .livePhoto ||
-                            photoAsset.mediaSubType == .localLivePhoto {
+                        if photoAsset.mediaSubType.isLivePhoto {
                             photoAsset.getLivePhotoURL(
                                 imageFileURL: toImageURL,
                                 videoFileURL: toVideoURL,

--- a/Sources/HXPhotoPicker/Picker/Extension/Picker+PHAsset.swift
+++ b/Sources/HXPhotoPicker/Picker/Extension/Picker+PHAsset.swift
@@ -27,7 +27,7 @@ extension PHAsset {
     var isLivePhoto: Bool {
         var isLivePhoto: Bool = false
         if #available(iOS 9.1, *) {
-            isLivePhoto = mediaSubtypes == .photoLive
+            isLivePhoto = mediaSubtypes.contains(.photoLive)
             if #available(iOS 11, *) {
                 if playbackStyle == .livePhoto {
                     isLivePhoto = true
@@ -37,8 +37,8 @@ extension PHAsset {
         return isLivePhoto
     }
     
-    var isHDRPhoto: Bool {
-        return mediaSubtypes.contains(.photoHDR) || mediaSubtypes == .init(rawValue: 512)
+    var isHDR: Bool {
+        return mediaSubtypes.contains(.photoHDR) || mediaSubtypes.contains(.init(rawValue: 512))
     }
     
     /// 如果在获取到PHAsset之前还未下载的iCloud，之后下载了还是会返回存在

--- a/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+Image.swift
+++ b/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+Image.swift
@@ -65,7 +65,7 @@ public extension PhotoAsset {
             switch result {
             case .success(let dataResult):
                 let image = {
-                    if phAsset.isHDRPhoto {
+                    if self.mediaSubType.isHDRPhoto {
                         return UIImage.HDRDecoded(dataResult.imageData)
                     } else {
                         return UIImage(data: dataResult.imageData)?.normalizedImage()

--- a/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+Request.swift
+++ b/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+Request.swift
@@ -153,7 +153,7 @@ public extension PhotoAsset {
                     return
                 }
                 let image = {
-                    if phAsset.isHDRPhoto {
+                    if self.mediaSubType.isHDRPhoto {
                         return UIImage.HDRDecoded(dataResult.imageData)
                     } else {
                         return UIImage(data: dataResult.imageData)?.normalizedImage()

--- a/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+URL.swift
+++ b/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+URL.swift
@@ -40,8 +40,7 @@ public extension PhotoAsset {
         completion: @escaping AssetURLCompletion
     ) {
         if mediaType == .photo {
-            if mediaSubType == .livePhoto ||
-                mediaSubType == .localLivePhoto {
+            if mediaSubType.isLivePhoto {
                 getLivePhotoURL(
                     imageFileURL: fileConfig?.imageURL,
                     videoFileURL: fileConfig?.videoURL,

--- a/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+Video.swift
+++ b/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset+Video.swift
@@ -36,7 +36,7 @@ extension PhotoAsset {
             resultHandler(.failure(.invalidPHAsset))
             return
         }
-        if mediaSubType == .livePhoto {
+        if mediaSubType.isLivePhoto {
             if let exportParameter = exportParameter {
                 AssetManager.exportVideoURL(
                     forVideo: phAsset,

--- a/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset.swift
+++ b/Sources/HXPhotoPicker/Picker/Model/PhotoAsset/PhotoAsset.swift
@@ -106,7 +106,6 @@ open class PhotoAsset: Equatable {
     public var isGifAsset: Bool { mediaSubType.isGif }
     public var isLocalAsset: Bool { mediaSubType.isLocal }
     public var isNetworkAsset: Bool { mediaSubType.isNetwork }
-    public var isHDRAsset: Bool { mediaSubType.isHDRPhoto }
     
     /// 根据系统相册里对应的 PHAsset 数据初始化
     /// - Parameter asset: 系统相册里对应的 PHAsset 数据

--- a/Sources/HXPhotoPicker/Picker/Model/PickerManager.swift
+++ b/Sources/HXPhotoPicker/Picker/Model/PickerManager.swift
@@ -220,7 +220,7 @@ extension PickerManager {
                     }
                 }
                 if self.config.selectOptions.contains(.HDRPhoto) {
-                    if photoAsset.phAsset!.isHDRPhoto {
+                    if photoAsset.mediaSubType == .image && photoAsset.phAsset!.isHDR {
                         photoAsset.mediaSubType = .HDRPhoto
                     }
                 }

--- a/Sources/HXPhotoPicker/Picker/Protocol/Fetch/PhotoFetchAsset.swift
+++ b/Sources/HXPhotoPicker/Picker/Protocol/Fetch/PhotoFetchAsset.swift
@@ -67,7 +67,7 @@ public extension PhotoFetchAsset {
                 }
             }
             if config.selectOptions.contains(.HDRPhoto) {
-                if phAsset.isHDRPhoto {
+                if photoAsset.mediaSubType == .image && phAsset.isHDR {
                     photoAsset.mediaSubType = .HDRPhoto
                 }
             }

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerViewCell.swift
@@ -323,11 +323,10 @@ extension PhotoPickerViewCell {
 //                assetTypeIcon.image = .imageResource.picker.photoList.cell.videoEdited.image
 //            }
 //            #endif
-        }else if photoAsset.mediaSubType == .livePhoto ||
-                    photoAsset.mediaSubType == .localLivePhoto {
+        }else if photoAsset.mediaSubType.isLivePhoto {
             assetTypeLb.text = .textPhotoList.cell.LivePhotoTitle.text
             assetTypeMaskView.isHidden = false
-        }else if photoAsset.mediaSubType == .HDRPhoto {
+        }else if photoAsset.mediaSubType.isHDRPhoto {
             assetTypeLb.text = .textPhotoList.cell.HDRPhotoTitle.text
             assetTypeMaskView.isHidden = false
         }else {

--- a/Sources/HXPhotoPicker/Picker/View/PhotoPreviewContentPhotoView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/PhotoPreviewContentPhotoView.swift
@@ -374,7 +374,7 @@ extension PhotoPreviewContentPhotoView {
                 guard let self = self, self.photoAsset == asset else {
                     return
                 }
-                if inICloud || asset.isHDRAsset {
+                if inICloud || asset.mediaSubType.isHDRPhoto {
                     self.requestPreviewImageData()
                 }else {
                     self.requestPreviewImage()
@@ -482,7 +482,7 @@ extension PhotoPreviewContentPhotoView {
                             }
                         }
                     }
-                    if asset.isHDRAsset {
+                    if asset.mediaSubType.isHDRPhoto {
                         handler(UIImage.HDRDecoded(dataResult.imageData))
                     } else {
                         let dataCount = CGFloat(dataResult.imageData.count)

--- a/Swift/Classes/Controller/PickerResultViewController.swift
+++ b/Swift/Classes/Controller/PickerResultViewController.swift
@@ -609,8 +609,7 @@ class PickerResultViewController: UIViewController,
                     )
                 }, rightActionTitle: "取消") { (alertAction) in }
         } longPressHandler: { index, photoAsset, photoBrowser in
-            if photoAsset.mediaSubType == .localLivePhoto ||
-               photoAsset.mediaSubType == .livePhoto {
+            if photoAsset.mediaSubType.isLivePhoto {
                 return
             }
             // 长按事件

--- a/Swift/Classes/Controller/WeChatViewController.swift
+++ b/Swift/Classes/Controller/WeChatViewController.swift
@@ -196,8 +196,7 @@ class WeChatViewCell: UITableViewCell {
                     stateLb.text = "GIF"
                     stateMaskLayer.isHidden = false
                 }
-            }else if photoAsset.mediaSubType == .livePhoto ||
-                        photoAsset.mediaSubType == .localLivePhoto {
+            }else if photoAsset.mediaSubType.isLivePhoto {
                 stateLb.text = "Live"
                 stateMaskLayer.isHidden = false
             }else {


### PR DESCRIPTION
1、将(.livePhoto || .localLivePhoto)改为isLivePhoto，避免遗漏
2、当mediaSubType为image时，才去设置mediaSubType = .HDRPhoto，LivePhoto也有可能是HDR，会覆盖mediaSubType