### PR TITLE
兼容RTL

### DIFF
--- a/Sources/HXPhotoPicker/Core/Extension/Core+LayerRTLFrame.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+LayerRTLFrame.swift
@@ -1,0 +1,99 @@
+import UIKit
+
+private var refWidthKey: UInt8 = 0
+
+extension CALayer {
+    /// 参照宽度，也就是【父图层】的宽度。
+    /// - 如果【父图层】是`CAScrollLayer`最好将其设置为它的`内容宽度`。
+    @objc var hxPicker_refWidth: CGFloat {
+        set { objc_setAssociatedObject(self, &refWidthKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+        get { objc_getAssociatedObject(self, &refWidthKey) as? CGFloat ?? superlayer?.bounds.maxX ?? 0 }
+    }
+    
+    var hxPicker_frame: CGRect {
+        set {
+            guard hxPicker_isRTL() else {
+                frame = newValue
+                return
+            }
+            let x = hxPicker_refWidth - newValue.maxX
+            frame = CGRect(origin: CGPoint(x: x, y: newValue.origin.y), size: newValue.size)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return CGRect(origin: CGPoint(x: x, y: frame.origin.y), size: frame.size)
+        }
+    }
+    
+    var hxPicker_position: CGPoint {
+        set {
+            guard hxPicker_isRTL() else {
+                position = newValue
+                return
+            }
+            let positionX = hxPicker_refWidth - newValue.x
+            position = CGPoint(x: positionX, y: newValue.y)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return position
+            }
+            let positionX = hxPicker_refWidth - position.x
+            return CGPoint(x: positionX, y: position.y)
+        }
+    }
+    
+    var hxPicker_x: CGFloat {
+        set {
+            guard hxPicker_isRTL() else {
+                frame.origin.x = newValue
+                return
+            }
+            let x = hxPicker_refWidth - frame.width - newValue
+            frame.origin.x = x
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame.origin.x
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return x
+        }
+    }
+    
+    var hxPicker_midX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.midX
+        }
+        let midX = hxPicker_refWidth - frame.midX
+        return midX
+    }
+    
+    var hxPicker_maxX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.maxX
+        }
+        return hxPicker_refWidth - frame.origin.x
+    }
+    
+    /// 相对【自身宽度】的转换值
+    func hxPicker_valueFromSelf(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (bounds.width - v) : v
+    }
+    
+    /// 相对【参照宽度】的转换值
+    func hxPicker_valueFromRef(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (hxPicker_refWidth - v) : v
+    }
+}
+
+extension CALayer {
+    /// 沿着Y轴180°翻转（水平镜像）
+    func hxPicker_flip() {
+        guard hxPicker_isRTL() else { return }
+        transform = CATransform3DMakeRotation(CGFloat.pi, 0, 1, 0)
+    }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
@@ -434,3 +434,16 @@ extension CGImagePropertyOrientation {
         }
     }
 }
+
+// MARK: RTL safe image
+extension UIImage {
+    var hxPicker_image: UIImage? {
+        guard hxPicker_isRTL(),
+                  imageOrientation != .upMirrored,
+                  let cgImage
+            else { return self }
+            return UIImage(cgImage: cgImage,
+                           scale: scale,
+                           orientation: .upMirrored)
+        }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UILabel.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UILabel.swift
@@ -27,3 +27,30 @@ extension UILabel {
         return .zero
     }
 }
+
+extension UILabel {
+    /// 文本对齐方向
+    var hxpicker_alignment: NSTextAlignment {
+        set {
+            switch newValue {
+            case .left:
+                textAlignment = hxPicker_isRTL() ? .right : .left
+            case .right:
+                textAlignment = hxPicker_isRTL() ? .left : .right
+            default:
+                textAlignment = newValue
+            }
+        }
+        
+        get {
+            switch textAlignment {
+            case .left:
+                return hxPicker_isRTL() ? .right : textAlignment
+            case .right:
+                return hxPicker_isRTL() ? .left : textAlignment
+            default:
+                return textAlignment
+            }
+        }
+    }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIViewRTLFrame.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIViewRTLFrame.swift
@@ -1,0 +1,99 @@
+import UIKit
+
+private var refWidthKey: UInt8 = 0
+
+extension UIView {
+    /// 参照宽度，也就是【父视图】的宽度。
+    /// - 如果【父视图】是`UIScrollView`最好将其设置为它的`contentSize.width`。
+    @objc var hxPicker_refWidth: CGFloat {
+        set { objc_setAssociatedObject(self, &refWidthKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+        get { objc_getAssociatedObject(self, &refWidthKey) as? CGFloat ?? superview?.bounds.maxX ?? 0 }
+    }
+    
+    var hxPicker_frame: CGRect {
+        set {
+            guard hxPicker_isRTL() else {
+                frame = newValue
+                return
+            }
+            let x = hxPicker_refWidth - newValue.maxX
+            frame = CGRect(origin: CGPoint(x: x, y: newValue.origin.y), size: newValue.size)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return CGRect(origin: CGPoint(x: x, y: frame.origin.y), size: frame.size)
+        }
+    }
+    
+    var hxPicker_center: CGPoint {
+        set {
+            guard hxPicker_isRTL() else {
+                center = newValue
+                return
+            }
+            let centerX = hxPicker_refWidth - newValue.x
+            center = CGPoint(x: centerX, y: newValue.y)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return center
+            }
+            let centerX = hxPicker_refWidth - center.x
+            return CGPoint(x: centerX, y: center.y)
+        }
+    }
+    
+    var hxPicker_x: CGFloat {
+        set {
+            guard hxPicker_isRTL() else {
+                frame.origin.x = newValue
+                return
+            }
+            let x = hxPicker_refWidth - frame.width - newValue
+            frame.origin.x = x
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame.origin.x
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return x
+        }
+    }
+    
+    var hxPicker_midX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.midX
+        }
+        let midX = hxPicker_refWidth - frame.midX
+        return midX
+    }
+    
+    var hxPicker_maxX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.maxX
+        }
+        return hxPicker_refWidth - frame.origin.x
+    }
+    
+    /// 相对【自身宽度】的转换值
+    @objc func hxPicker_valueFromSelf(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (bounds.width - v) : v
+    }
+    
+    /// 相对【参照宽度】的转换值
+    func hxPicker_valueFromRef(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (hxPicker_refWidth - v) : v
+    }
+}
+
+extension UIView {
+    /// 沿着Y轴180°翻转（水平镜像）
+    func hxPicker_flip() {
+        guard hxPicker_isRTL() else { return }
+        layer.transform = CATransform3DMakeRotation(CGFloat.pi, 0, 1, 0)
+    }
+}

--- a/Sources/HXPhotoPicker/Core/Model/AppearanceStyle.swift
+++ b/Sources/HXPhotoPicker/Core/Model/AppearanceStyle.swift
@@ -15,3 +15,7 @@ public enum AppearanceStyle: Int {
     /// 暗黑风格
     case dark = 2
 }
+
+public func hxPicker_isRTL() -> Bool{
+    return PhotoManager.isRTL
+}

--- a/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
+++ b/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
@@ -37,6 +37,15 @@ public final class PhotoManager: NSObject {
     }
     public static var HUDView: PhotoHUDProtocol.Type = ProgressHUD.self
     
+    /// 是否阿语RTL布局
+    public static var isRTL: Bool {
+        var isRTL = false
+        if let languageType = PhotoManager.shared.languageType {
+            isRTL = languageType == .arabic
+        }
+        return isRTL
+    }
+    
     public var isDebugLogsEnabled: Bool = false
     
     /// 当前语言文件，每次创建PhotoPickerController判断是否需要重新创建

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
@@ -230,6 +230,9 @@ public class PhotoPreviewViewController: PhotoBaseViewController {
 extension PhotoPreviewViewController {
      
     private func initView() {
+        //强制LTR，避免阿语下预览图片内容被镜像
+        view.semanticContentAttribute = .forceLeftToRight
+        
         collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .horizontal
         collectionViewLayout.minimumLineSpacing = 0

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
@@ -230,9 +230,6 @@ public class PhotoPreviewViewController: PhotoBaseViewController {
 extension PhotoPreviewViewController {
      
     private func initView() {
-        //强制LTR，避免阿语下预览图片内容被镜像
-        view.semanticContentAttribute = .forceLeftToRight
-        
         collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .horizontal
         collectionViewLayout.minimumLineSpacing = 0
@@ -382,6 +379,10 @@ extension PhotoPreviewViewController {
             view.addSubview(navBgView)
             self.navBgView = navBgView
         }
+        
+        //强制LTR，避免阿语下预览图片内容被镜像
+        view.semanticContentAttribute = .forceLeftToRight
+        collectionView.semanticContentAttribute = .forceLeftToRight
     }
     func configBottomViewFrame() {
         if !config.isShowBottomView {

--- a/Sources/HXPhotoPicker/Picker/View/Album/AlbumListView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Album/AlbumListView.swift
@@ -181,7 +181,7 @@ open class AlbumListView: UIView, PhotoAlbumList, UITableViewDataSource, UITable
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        tableView.frame = bounds
+        tableView.hxPicker_frame = bounds
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/HXPhotoPicker/Picker/View/Cell/Album/AlbumViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/Album/AlbumViewCell.swift
@@ -111,29 +111,29 @@ open class AlbumViewCell: AlbumViewBaseCell {
         let width = contentView.width
         let coverMargin: CGFloat = 5
         let coverWidth = height - (coverMargin * 2)
-        albumCoverView.frame = CGRect(x: coverMargin, y: coverMargin, width: coverWidth, height: coverWidth)
+        albumCoverView.hxPicker_frame = CGRect(x: coverMargin, y: coverMargin, width: coverWidth, height: coverWidth)
         
         if viewController?.splitViewController != nil {
-            tickView.x = width - 12 - tickView.width
+            tickView.hxPicker_x = width - 12 - tickView.width
         }else {
-            tickView.x = width - 12 - tickView.width - UIDevice.rightMargin
+            tickView.hxPicker_x = width - 12 - tickView.width - UIDevice.rightMargin
         }
         tickView.centerY = height * 0.5
         
-        albumNameLb.x = albumCoverView.frame.maxX + 10
-        albumNameLb.size = CGSize(width: tickView.x - albumNameLb.x - 20, height: 16)
+        albumNameLb.hxPicker_x = albumCoverView.hxPicker_frame.maxX + 10
+        albumNameLb.size = CGSize(width: tickView.hxPicker_x - albumNameLb.hxPicker_x - 20, height: 16)
         
         if config.isShowPhotoCount {
             albumNameLb.centerY = height / 2 - albumNameLb.height / 2
             
-            photoCountLb.x = albumCoverView.frame.maxX + 10
-            photoCountLb.y = albumNameLb.frame.maxY + 5
-            photoCountLb.size = CGSize(width: width - photoCountLb.x - 20, height: 14)
+            photoCountLb.hxPicker_x = albumCoverView.hxPicker_frame.maxX + 10
+            photoCountLb.y = albumNameLb.hxPicker_frame.maxY + 5
+            photoCountLb.size = CGSize(width: width - photoCountLb.hxPicker_x - 20, height: 14)
         }else {
             albumNameLb.centerY = height / 2
         }
         
-        bottomLineView.frame = CGRect(x: coverMargin, y: height - 0.5, width: width - coverMargin * 2, height: 0.5)
+        bottomLineView.hxPicker_frame = CGRect(x: coverMargin, y: height - 0.5, width: width - coverMargin * 2, height: 0.5)
     }
     
     open override func layoutSubviews() {

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerSelectableViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerSelectableViewCell.swift
@@ -114,15 +114,15 @@ open class PhotoPickerSelectableViewCell: PhotoPickerViewCell {
         let topMargin = config.selectBoxTopMargin
         let rightMargin = config.selectBoxRightMargin
         let rect = CGRect(x: self.width - rightMargin - width, y: topMargin, width: width, height: height)
-        if selectControl.frame.equalTo(rect) {
+        if selectControl.hxPicker_frame.equalTo(rect) {
             return
         }
         if let photoAsset = photoAsset, photoAsset.isScrolling {
             let x = selectControl.x
-            selectControl.frame = rect
-            selectControl.x = x
+            selectControl.hxPicker_frame = rect
+            selectControl.hxPicker_x = x
         }else {
-            selectControl.frame = rect
+            selectControl.hxPicker_frame = rect
         }
     }
     

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerViewCell.swift
@@ -62,14 +62,14 @@ open class PhotoPickerViewCell: PhotoPickerBaseViewCell {
         
         selectMaskLayer = CALayer()
         selectMaskLayer.backgroundColor = UIColor.black.withAlphaComponent(0.6).cgColor
-        selectMaskLayer.frame = bounds
+        selectMaskLayer.hxPicker_frame = bounds
         selectMaskLayer.isHidden = true
         photoView.layer.addSublayer(selectMaskLayer)
         
         assetTypeLb = UILabel()
         assetTypeLb.font = .mediumPingFang(ofSize: 14)
         assetTypeLb.textColor = .white
-        assetTypeLb.textAlignment = .right
+        assetTypeLb.hxpicker_alignment = .right
         contentView.addSubview(assetTypeLb)
         
         assetTypeIcon = UIImageView(image: .imageResource.picker.photoList.cell.video.image)
@@ -203,10 +203,10 @@ open class PhotoPickerViewCell: PhotoPickerBaseViewCell {
     /// 布局
     open override func layoutView() {
         super.layoutView()
-        iCloudMarkView.x = width - iCloudMarkView.width - 5
+        iCloudMarkView.hxPicker_x = width - iCloudMarkView.width - 5
         iCloudMarkView.y = 5
         
-        assetTypeMaskView.frame = CGRect(x: 0, y: photoView.height - 25, width: width, height: 25)
+        assetTypeMaskView.hxPicker_frame = CGRect(x: 0, y: photoView.height - 25, width: width, height: 25)
         let assetTypeMakeFrame = CGRect(
             x: 0,
             y: -5,
@@ -226,25 +226,27 @@ open class PhotoPickerViewCell: PhotoPickerBaseViewCell {
         if updateFrame {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
-            assetTypeMaskLayer.frame = assetTypeMakeFrame
-            selectMaskLayer.frame = photoView.bounds
-            disableMaskLayer.frame = photoView.bounds
+            assetTypeMaskLayer.hxPicker_frame = assetTypeMakeFrame
+            selectMaskLayer.hxPicker_frame = photoView.bounds
+            disableMaskLayer.hxPicker_frame = photoView.bounds
             CATransaction.commit()
         }
-        assetTypeLb.frame = CGRect(x: 0, y: height - 19, width: width - 5, height: 18)
+        assetTypeLb.hxPicker_frame = CGRect(x: 0, y: height - 19, width: width - 5, height: 18)
         if let imageSize = assetTypeIcon.image?.size {
             assetTypeIcon.size = imageSize
         }
-        assetTypeIcon.x = 5
+        //备注：很多适配RTL的工程都会Hook调整alignment，因此该处根据当前的alignment来调整图标的位置（避免遮挡）
+        let isAssetTypeLbInRight = assetTypeLb.hxpicker_alignment == .right
+        assetTypeIcon.hxPicker_x = isAssetTypeLbInRight ? 5 : (width - assetTypeIcon.width - 5)
         assetTypeIcon.y = height - assetTypeIcon.height - 5
         assetTypeLb.centerY = assetTypeIcon.centerY
         if let imageSize = assetEditMarkIcon.image?.size {
             assetEditMarkIcon.size = imageSize
         }
-        assetEditMarkIcon.x = 5
+        assetEditMarkIcon.hxPicker_x = 5
         assetEditMarkIcon.y = height - assetEditMarkIcon.height - 5
         
-        loaddingView.frame = bounds
+        loaddingView.hxPicker_frame = bounds
     }
     
     /// 设置高亮时的遮罩

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerWeChatViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerWeChatViewCell.swift
@@ -14,7 +14,7 @@ open class PhotoPickerWeChatViewCell: PhotoPickerSelectableViewCell {
     open override func initView() {
         super.initView()
         titleLb = UILabel()
-        titleLb.textAlignment = .center
+        titleLb.hxpicker_alignment = .center
         titleLb.textColor = .white
         titleLb.font = .semiboldPingFang(ofSize: 15)
         titleLb.isHidden = true
@@ -32,6 +32,6 @@ open class PhotoPickerWeChatViewCell: PhotoPickerSelectableViewCell {
     
     open override func layoutView() {
         super.layoutView()
-        titleLb.x = 10
+        titleLb.hxPicker_x = 10
     }
 }


### PR DESCRIPTION
**1、概要**

我们的HXPhotoPicker是按照frame布局的，因此在阿语环境下避免不了有些兼容问题，我对其做了兼容修改，你看下要不要合并（Issues上看到也有人反馈阿语的兼容问题）

**2、主要调整：**

1、新增了2个分类扩展：对UIView、CALayer的frame，x等属性做了支持RTL
2、新增了UILabel的alignment，支持RTL

备注：核心就是将视图布局的xxx.frame 改成支持RTL的hxPicker_frame，x 改成 hxPicker_x（坐标内部会做RTL兼容）

**3、修复3处阿语不兼容：**

1、相册选择页面：视频时长与视频图标UI重叠
2、点击顶部-相册分类列表：打勾以及相册名字与数量UI重写错误
3、照片预览：按住图片-拖动，图片会被镜像，释放之后又正确显示

