### PR TITLE
对阿语的RTL布局做了兼容

### DIFF
--- a/Sources/HXPhotoPicker/Core/Extension/Core+LayerRTLFrame.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+LayerRTLFrame.swift
@@ -12,7 +12,7 @@ extension CALayer {
     
     var hxPicker_frame: CGRect {
         set {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 frame = newValue
                 return
             }
@@ -20,7 +20,7 @@ extension CALayer {
             frame = CGRect(origin: CGPoint(x: x, y: newValue.origin.y), size: newValue.size)
         }
         get {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 return frame
             }
             let x = hxPicker_refWidth - frame.maxX
@@ -30,7 +30,7 @@ extension CALayer {
     
     var hxPicker_position: CGPoint {
         set {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 position = newValue
                 return
             }
@@ -38,7 +38,7 @@ extension CALayer {
             position = CGPoint(x: positionX, y: newValue.y)
         }
         get {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 return position
             }
             let positionX = hxPicker_refWidth - position.x
@@ -48,7 +48,7 @@ extension CALayer {
     
     var hxPicker_x: CGFloat {
         set {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 frame.origin.x = newValue
                 return
             }
@@ -56,7 +56,7 @@ extension CALayer {
             frame.origin.x = x
         }
         get {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 return frame.origin.x
             }
             let x = hxPicker_refWidth - frame.maxX
@@ -65,7 +65,7 @@ extension CALayer {
     }
     
     var hxPicker_midX: CGFloat {
-        guard hxPicker_isRTL() else {
+        guard PhotoManager.isRTL else {
             return frame.midX
         }
         let midX = hxPicker_refWidth - frame.midX
@@ -73,7 +73,7 @@ extension CALayer {
     }
     
     var hxPicker_maxX: CGFloat {
-        guard hxPicker_isRTL() else {
+        guard PhotoManager.isRTL else {
             return frame.maxX
         }
         return hxPicker_refWidth - frame.origin.x
@@ -81,19 +81,19 @@ extension CALayer {
     
     /// 相对【自身宽度】的转换值
     func hxPicker_valueFromSelf(_ v: CGFloat) -> CGFloat {
-        hxPicker_isRTL() ? (bounds.width - v) : v
+        PhotoManager.isRTL ? (bounds.width - v) : v
     }
     
     /// 相对【参照宽度】的转换值
     func hxPicker_valueFromRef(_ v: CGFloat) -> CGFloat {
-        hxPicker_isRTL() ? (hxPicker_refWidth - v) : v
+        PhotoManager.isRTL ? (hxPicker_refWidth - v) : v
     }
 }
 
 extension CALayer {
     /// 沿着Y轴180°翻转（水平镜像）
     func hxPicker_flip() {
-        guard hxPicker_isRTL() else { return }
+        guard PhotoManager.isRTL else { return }
         transform = CATransform3DMakeRotation(CGFloat.pi, 0, 1, 0)
     }
 }

--- a/Sources/HXPhotoPicker/Core/Extension/Core+LayerRTLFrame.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+LayerRTLFrame.swift
@@ -1,0 +1,99 @@
+import UIKit
+
+private var refWidthKey: UInt8 = 0
+
+extension CALayer {
+    /// 参照宽度，也就是【父图层】的宽度。
+    /// - 如果【父图层】是`CAScrollLayer`最好将其设置为它的`内容宽度`。
+    @objc var hxPicker_refWidth: CGFloat {
+        set { objc_setAssociatedObject(self, &refWidthKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+        get { objc_getAssociatedObject(self, &refWidthKey) as? CGFloat ?? superlayer?.bounds.maxX ?? 0 }
+    }
+    
+    var hxPicker_frame: CGRect {
+        set {
+            guard hxPicker_isRTL() else {
+                frame = newValue
+                return
+            }
+            let x = hxPicker_refWidth - newValue.maxX
+            frame = CGRect(origin: CGPoint(x: x, y: newValue.origin.y), size: newValue.size)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return CGRect(origin: CGPoint(x: x, y: frame.origin.y), size: frame.size)
+        }
+    }
+    
+    var hxPicker_position: CGPoint {
+        set {
+            guard hxPicker_isRTL() else {
+                position = newValue
+                return
+            }
+            let positionX = hxPicker_refWidth - newValue.x
+            position = CGPoint(x: positionX, y: newValue.y)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return position
+            }
+            let positionX = hxPicker_refWidth - position.x
+            return CGPoint(x: positionX, y: position.y)
+        }
+    }
+    
+    var hxPicker_x: CGFloat {
+        set {
+            guard hxPicker_isRTL() else {
+                frame.origin.x = newValue
+                return
+            }
+            let x = hxPicker_refWidth - frame.width - newValue
+            frame.origin.x = x
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame.origin.x
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return x
+        }
+    }
+    
+    var hxPicker_midX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.midX
+        }
+        let midX = hxPicker_refWidth - frame.midX
+        return midX
+    }
+    
+    var hxPicker_maxX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.maxX
+        }
+        return hxPicker_refWidth - frame.origin.x
+    }
+    
+    /// 相对【自身宽度】的转换值
+    func hxPicker_valueFromSelf(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (bounds.width - v) : v
+    }
+    
+    /// 相对【参照宽度】的转换值
+    func hxPicker_valueFromRef(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (hxPicker_refWidth - v) : v
+    }
+}
+
+extension CALayer {
+    /// 沿着Y轴180°翻转（水平镜像）
+    func hxPicker_flip() {
+        guard hxPicker_isRTL() else { return }
+        transform = CATransform3DMakeRotation(CGFloat.pi, 0, 1, 0)
+    }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
@@ -434,16 +434,3 @@ extension CGImagePropertyOrientation {
         }
     }
 }
-
-// MARK: RTL safe image
-extension UIImage {
-    var hxPicker_image: UIImage? {
-        guard hxPicker_isRTL(),
-                  imageOrientation != .upMirrored,
-                  let cgImage
-            else { return self }
-            return UIImage(cgImage: cgImage,
-                           scale: scale,
-                           orientation: .upMirrored)
-        }
-}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
@@ -434,3 +434,16 @@ extension CGImagePropertyOrientation {
         }
     }
 }
+
+// MARK: RTL safe image
+extension UIImage {
+    var hxPicker_image: UIImage? {
+        guard hxPicker_isRTL(),
+                  imageOrientation != .upMirrored,
+                  let cgImage
+            else { return self }
+            return UIImage(cgImage: cgImage,
+                           scale: scale,
+                           orientation: .upMirrored)
+        }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UILabel.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UILabel.swift
@@ -34,9 +34,9 @@ extension UILabel {
         set {
             switch newValue {
             case .left:
-                textAlignment = hxPicker_isRTL() ? .right : .left
+                textAlignment = PhotoManager.isRTL ? .right : .left
             case .right:
-                textAlignment = hxPicker_isRTL() ? .left : .right
+                textAlignment = PhotoManager.isRTL ? .left : .right
             default:
                 textAlignment = newValue
             }
@@ -45,9 +45,9 @@ extension UILabel {
         get {
             switch textAlignment {
             case .left:
-                return hxPicker_isRTL() ? .right : textAlignment
+                return PhotoManager.isRTL ? .right : textAlignment
             case .right:
-                return hxPicker_isRTL() ? .left : textAlignment
+                return PhotoManager.isRTL ? .left : textAlignment
             default:
                 return textAlignment
             }

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UILabel.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UILabel.swift
@@ -27,3 +27,30 @@ extension UILabel {
         return .zero
     }
 }
+
+extension UILabel {
+    /// 文本对齐方向
+    var hxpicker_alignment: NSTextAlignment {
+        set {
+            switch newValue {
+            case .left:
+                textAlignment = hxPicker_isRTL() ? .right : .left
+            case .right:
+                textAlignment = hxPicker_isRTL() ? .left : .right
+            default:
+                textAlignment = newValue
+            }
+        }
+        
+        get {
+            switch textAlignment {
+            case .left:
+                return hxPicker_isRTL() ? .right : textAlignment
+            case .right:
+                return hxPicker_isRTL() ? .left : textAlignment
+            default:
+                return textAlignment
+            }
+        }
+    }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIViewRTLFrame.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIViewRTLFrame.swift
@@ -1,0 +1,99 @@
+import UIKit
+
+private var refWidthKey: UInt8 = 0
+
+extension UIView {
+    /// 参照宽度，也就是【父视图】的宽度。
+    /// - 如果【父视图】是`UIScrollView`最好将其设置为它的`contentSize.width`。
+    @objc var hxPicker_refWidth: CGFloat {
+        set { objc_setAssociatedObject(self, &refWidthKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+        get { objc_getAssociatedObject(self, &refWidthKey) as? CGFloat ?? superview?.bounds.maxX ?? 0 }
+    }
+    
+    var hxPicker_frame: CGRect {
+        set {
+            guard hxPicker_isRTL() else {
+                frame = newValue
+                return
+            }
+            let x = hxPicker_refWidth - newValue.maxX
+            frame = CGRect(origin: CGPoint(x: x, y: newValue.origin.y), size: newValue.size)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return CGRect(origin: CGPoint(x: x, y: frame.origin.y), size: frame.size)
+        }
+    }
+    
+    var hxPicker_center: CGPoint {
+        set {
+            guard hxPicker_isRTL() else {
+                center = newValue
+                return
+            }
+            let centerX = hxPicker_refWidth - newValue.x
+            center = CGPoint(x: centerX, y: newValue.y)
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return center
+            }
+            let centerX = hxPicker_refWidth - center.x
+            return CGPoint(x: centerX, y: center.y)
+        }
+    }
+    
+    var hxPicker_x: CGFloat {
+        set {
+            guard hxPicker_isRTL() else {
+                frame.origin.x = newValue
+                return
+            }
+            let x = hxPicker_refWidth - frame.width - newValue
+            frame.origin.x = x
+        }
+        get {
+            guard hxPicker_isRTL() else {
+                return frame.origin.x
+            }
+            let x = hxPicker_refWidth - frame.maxX
+            return x
+        }
+    }
+    
+    var hxPicker_midX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.midX
+        }
+        let midX = hxPicker_refWidth - frame.midX
+        return midX
+    }
+    
+    var hxPicker_maxX: CGFloat {
+        guard hxPicker_isRTL() else {
+            return frame.maxX
+        }
+        return hxPicker_refWidth - frame.origin.x
+    }
+    
+    /// 相对【自身宽度】的转换值
+    @objc func hxPicker_valueFromSelf(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (bounds.width - v) : v
+    }
+    
+    /// 相对【参照宽度】的转换值
+    func hxPicker_valueFromRef(_ v: CGFloat) -> CGFloat {
+        hxPicker_isRTL() ? (hxPicker_refWidth - v) : v
+    }
+}
+
+extension UIView {
+    /// 沿着Y轴180°翻转（水平镜像）
+    func hxPicker_flip() {
+        guard hxPicker_isRTL() else { return }
+        layer.transform = CATransform3DMakeRotation(CGFloat.pi, 0, 1, 0)
+    }
+}

--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIViewRTLFrame.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIViewRTLFrame.swift
@@ -12,7 +12,7 @@ extension UIView {
     
     var hxPicker_frame: CGRect {
         set {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 frame = newValue
                 return
             }
@@ -20,7 +20,7 @@ extension UIView {
             frame = CGRect(origin: CGPoint(x: x, y: newValue.origin.y), size: newValue.size)
         }
         get {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 return frame
             }
             let x = hxPicker_refWidth - frame.maxX
@@ -30,7 +30,7 @@ extension UIView {
     
     var hxPicker_center: CGPoint {
         set {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 center = newValue
                 return
             }
@@ -38,7 +38,7 @@ extension UIView {
             center = CGPoint(x: centerX, y: newValue.y)
         }
         get {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 return center
             }
             let centerX = hxPicker_refWidth - center.x
@@ -48,7 +48,7 @@ extension UIView {
     
     var hxPicker_x: CGFloat {
         set {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 frame.origin.x = newValue
                 return
             }
@@ -56,7 +56,7 @@ extension UIView {
             frame.origin.x = x
         }
         get {
-            guard hxPicker_isRTL() else {
+            guard PhotoManager.isRTL else {
                 return frame.origin.x
             }
             let x = hxPicker_refWidth - frame.maxX
@@ -65,7 +65,7 @@ extension UIView {
     }
     
     var hxPicker_midX: CGFloat {
-        guard hxPicker_isRTL() else {
+        guard PhotoManager.isRTL else {
             return frame.midX
         }
         let midX = hxPicker_refWidth - frame.midX
@@ -73,7 +73,7 @@ extension UIView {
     }
     
     var hxPicker_maxX: CGFloat {
-        guard hxPicker_isRTL() else {
+        guard PhotoManager.isRTL else {
             return frame.maxX
         }
         return hxPicker_refWidth - frame.origin.x
@@ -81,19 +81,19 @@ extension UIView {
     
     /// 相对【自身宽度】的转换值
     @objc func hxPicker_valueFromSelf(_ v: CGFloat) -> CGFloat {
-        hxPicker_isRTL() ? (bounds.width - v) : v
+        PhotoManager.isRTL ? (bounds.width - v) : v
     }
     
     /// 相对【参照宽度】的转换值
     func hxPicker_valueFromRef(_ v: CGFloat) -> CGFloat {
-        hxPicker_isRTL() ? (hxPicker_refWidth - v) : v
+        PhotoManager.isRTL ? (hxPicker_refWidth - v) : v
     }
 }
 
 extension UIView {
     /// 沿着Y轴180°翻转（水平镜像）
     func hxPicker_flip() {
-        guard hxPicker_isRTL() else { return }
-        layer.transform = CATransform3DMakeRotation(CGFloat.pi, 0, 1, 0)
+        guard PhotoManager.isRTL else { return }
+        layer.transform = CATransform3DMakeRotation(.pi, 0, 1, 0)
     }
 }

--- a/Sources/HXPhotoPicker/Core/Model/AppearanceStyle.swift
+++ b/Sources/HXPhotoPicker/Core/Model/AppearanceStyle.swift
@@ -15,3 +15,7 @@ public enum AppearanceStyle: Int {
     /// 暗黑风格
     case dark = 2
 }
+
+public func hxPicker_isRTL() -> Bool{
+    return PhotoManager.isRTL
+}

--- a/Sources/HXPhotoPicker/Core/Model/AppearanceStyle.swift
+++ b/Sources/HXPhotoPicker/Core/Model/AppearanceStyle.swift
@@ -15,7 +15,3 @@ public enum AppearanceStyle: Int {
     /// 暗黑风格
     case dark = 2
 }
-
-public func hxPicker_isRTL() -> Bool{
-    return PhotoManager.isRTL
-}

--- a/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
+++ b/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
@@ -37,6 +37,15 @@ public final class PhotoManager: NSObject {
     }
     public static var HUDView: PhotoHUDProtocol.Type = ProgressHUD.self
     
+    /// 是否阿语RTL布局
+    public static var isRTL: Bool {
+        var isRTL = false
+        if let languageType = PhotoManager.shared.languageType {
+            isRTL = languageType == .arabic
+        }
+        return isRTL
+    }
+    
     public var isDebugLogsEnabled: Bool = false
     
     /// 当前语言文件，每次创建PhotoPickerController判断是否需要重新创建

--- a/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
+++ b/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
@@ -41,7 +41,11 @@ public final class PhotoManager: NSObject {
     public static var isRTL: Bool {
         var isRTL = false
         if let languageType = PhotoManager.shared.languageType {
-            isRTL = languageType == .arabic
+            if languageType == .system {
+                isRTL = PhotoManager.shared.languageStr == "ar"
+            } else {
+                isRTL = languageType == .arabic
+            }
         }
         return isRTL
     }

--- a/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
+++ b/Sources/HXPhotoPicker/Core/Util/PhotoManager.swift
@@ -39,15 +39,14 @@ public final class PhotoManager: NSObject {
     
     /// 是否阿语RTL布局
     public static var isRTL: Bool {
-        var isRTL = false
-        if let languageType = PhotoManager.shared.languageType {
-            if languageType == .system {
-                isRTL = PhotoManager.shared.languageStr == "ar"
-            } else {
-                isRTL = languageType == .arabic
-            }
+        guard let languageType = PhotoManager.shared.languageType else {
+            return false
         }
-        return isRTL
+        if languageType == .system {
+            return PhotoManager.shared.languageStr == "ar"
+        } else {
+            return languageType == .arabic
+        }
     }
     
     public var isDebugLogsEnabled: Bool = false

--- a/Sources/HXPhotoPicker/Picker/Controller/Album/PhotoAlbumViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Album/PhotoAlbumViewController.swift
@@ -52,6 +52,13 @@ public class PhotoAlbumViewController: UIViewController, PhotoAlbumController {
             tableView.sectionHeaderTopPadding = 0
         }
         view.addSubview(tableView)
+        if PhotoManager.isRTL {
+            navigationController?.navigationBar.semanticContentAttribute = .forceRightToLeft
+            tableView.semanticContentAttribute = .forceRightToLeft
+        }else {
+            navigationController?.navigationBar.semanticContentAttribute = .forceLeftToRight
+            tableView.semanticContentAttribute = .forceLeftToRight
+        }
         reloadData()
         updateColors()
     }
@@ -211,7 +218,7 @@ extension PhotoAlbumViewController: UITableViewDataSource, UITableViewDelegate {
             let data = datas[indexPath.section]
             let count = data.assetCollections.count
             let marginCount = rowCount - 1
-            let margin: CGFloat = assetCollections.count > Int(rowCount) * 2 ? 5 : 0
+            let margin: CGFloat = count > Int(rowCount) * 2 ? 5 : 0
             let itemWidth = (view.width - (30 + 12 * marginCount) - UIDevice.leftMargin - UIDevice.rightMargin) / rowCount - margin
             let fontHeight = config.albumController.albumNameFont.lineHeight + config.albumController.photoCountFont.lineHeight + 8
             let itemHeight = itemWidth + fontHeight + 20

--- a/Sources/HXPhotoPicker/Picker/Controller/Album/PhotoMyAlbumViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Album/PhotoMyAlbumViewController.swift
@@ -49,6 +49,11 @@ public class PhotoMyAlbumViewController: UIViewController, UICollectionViewDataS
             automaticallyAdjustsScrollViewInsets = false
         }
         view.addSubview(collectionView)
+        if PhotoManager.isRTL {
+            collectionView.semanticContentAttribute = .forceRightToLeft
+        }else {
+            collectionView.semanticContentAttribute = .forceLeftToRight
+        }
         updateColors()
     }
     

--- a/Sources/HXPhotoPicker/Picker/Controller/Photo/PhotoPickerController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Photo/PhotoPickerController.swift
@@ -219,6 +219,11 @@ open class PhotoPickerController: UINavigationController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        if PhotoManager.isRTL {
+            navigationBar.semanticContentAttribute = .forceRightToLeft
+        }else {
+            navigationBar.semanticContentAttribute = .forceLeftToRight
+        }
         setupDelegate()
         PhotoManager.shared.indicatorType = config.indicatorType
         PhotoManager.shared.loadNetworkVideoMode = config.previewView.loadNetworkVideoMode

--- a/Sources/HXPhotoPicker/Picker/Controller/Picker/PhotoPickerFilterViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Picker/PhotoPickerFilterViewController.swift
@@ -28,6 +28,13 @@ class PhotoPickerFilterViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        if PhotoManager.isRTL {
+            navigationController?.navigationBar.semanticContentAttribute = .forceRightToLeft
+            tableView.semanticContentAttribute = .forceRightToLeft
+        }else {
+            navigationController?.navigationBar.semanticContentAttribute = .forceLeftToRight
+            tableView.semanticContentAttribute = .forceLeftToRight
+        }
         if #available(iOS 13.0, *) {
             switch PhotoManager.shared.appearanceStyle {
             case .normal:
@@ -260,8 +267,8 @@ class PhotoPickerFilterViewController: UITableViewController {
 class PhotoPickerFilterViewCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
-        imageView?.centerX = 30
-        textLabel?.x = 60
+        imageView?.hxPicker_center.x = 30
+        textLabel?.hxPicker_x = 60
     }
 }
 

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
@@ -230,6 +230,9 @@ public class PhotoPreviewViewController: PhotoBaseViewController {
 extension PhotoPreviewViewController {
      
     private func initView() {
+        //强制LTR，避免阿语下预览图片内容被镜像
+        view.semanticContentAttribute = .forceLeftToRight
+        
         collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .horizontal
         collectionViewLayout.minimumLineSpacing = 0

--- a/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Preview/PhotoPreviewViewController.swift
@@ -230,9 +230,6 @@ public class PhotoPreviewViewController: PhotoBaseViewController {
 extension PhotoPreviewViewController {
      
     private func initView() {
-        //强制LTR，避免阿语下预览图片内容被镜像
-        view.semanticContentAttribute = .forceLeftToRight
-        
         collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .horizontal
         collectionViewLayout.minimumLineSpacing = 0
@@ -382,6 +379,10 @@ extension PhotoPreviewViewController {
             view.addSubview(navBgView)
             self.navBgView = navBgView
         }
+        
+        //强制LTR，避免阿语下预览图片内容被镜像
+        view.semanticContentAttribute = .forceLeftToRight
+        collectionView.semanticContentAttribute = .forceLeftToRight
     }
     func configBottomViewFrame() {
         if !config.isShowBottomView {

--- a/Sources/HXPhotoPicker/Picker/View/Album/AlbumListView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Album/AlbumListView.swift
@@ -181,7 +181,7 @@ open class AlbumListView: UIView, PhotoAlbumList, UITableViewDataSource, UITable
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        tableView.frame = bounds
+        tableView.hxPicker_frame = bounds
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/HXPhotoPicker/Picker/View/Album/PhotoAlbumHeaderView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Album/PhotoAlbumHeaderView.swift
@@ -44,13 +44,14 @@ public class PhotoAlbumHeaderView: UITableViewHeaderFooterView {
     public override func layoutSubviews() {
         super.layoutSubviews()
         
-        titleLb.x = 15
         titleLb.centerY = contentView.height / 2
-        titleLb.size = contentView.size
+        titleLb.height = contentView.height
+        titleLb.width = titleLb.textWidth
+        titleLb.hxPicker_x = 15
         
         if let btnWidth = allBtn.titleLabel?.textWidth {
             allBtn.size = .init(width: btnWidth, height: contentView.height)
-            allBtn.x = contentView.width - 15 - btnWidth
+            allBtn.hxPicker_x = contentView.width - 15 - btnWidth
         }
     }
     

--- a/Sources/HXPhotoPicker/Picker/View/Cell/Album/AlbumViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/Album/AlbumViewCell.swift
@@ -62,6 +62,7 @@ open class AlbumViewCell: AlbumViewBaseCell {
         contentView.addSubview(bottomLineView)
         
         tickView = TickView(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
+        tickView.hxPicker_frame =  CGRect(x: 0, y: 0, width: 30, height: 30)
         contentView.addSubview(tickView)
     }
     
@@ -119,16 +120,22 @@ open class AlbumViewCell: AlbumViewBaseCell {
             tickView.hxPicker_x = width - 12 - tickView.width - UIDevice.rightMargin
         }
         tickView.centerY = height * 0.5
-        
-        albumNameLb.hxPicker_x = albumCoverView.hxPicker_frame.maxX + 10
-        albumNameLb.size = CGSize(width: tickView.hxPicker_x - albumNameLb.hxPicker_x - 20, height: 16)
-        
+
+        //设置albumNameLb坐标
+        let albumNameLbX = albumCoverView.hxPicker_maxX + 10
+        //内容size自适应
+        let albumNameLbSize = albumNameLb.sizeThatFits(CGSize(width: tickView.hxPicker_x - albumNameLbX - 20, height: 16))
+        albumNameLb.hxPicker_frame = CGRect(origin: CGPoint(x: albumNameLbX, y: 0), size: albumNameLbSize)
+
         if config.isShowPhotoCount {
             albumNameLb.centerY = height / 2 - albumNameLb.height / 2
             
-            photoCountLb.hxPicker_x = albumCoverView.hxPicker_frame.maxX + 10
-            photoCountLb.y = albumNameLb.hxPicker_frame.maxY + 5
-            photoCountLb.size = CGSize(width: width - photoCountLb.hxPicker_x - 20, height: 14)
+            //设置photoCountL坐标
+            let photoCountLbX = albumNameLb.hxPicker_x
+            let photoCountLbY = albumNameLb.hxPicker_frame.maxY + 5
+            //内容size自适应
+            let photoCountLbSize = photoCountLb.sizeThatFits(CGSize(width: width - photoCountLbX - 20, height: 14))
+            photoCountLb.hxPicker_frame = CGRect(origin: CGPoint(x: photoCountLbX, y: photoCountLbY), size: photoCountLbSize)
         }else {
             albumNameLb.centerY = height / 2
         }

--- a/Sources/HXPhotoPicker/Picker/View/Cell/Album/AlbumViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/Album/AlbumViewCell.swift
@@ -111,29 +111,29 @@ open class AlbumViewCell: AlbumViewBaseCell {
         let width = contentView.width
         let coverMargin: CGFloat = 5
         let coverWidth = height - (coverMargin * 2)
-        albumCoverView.frame = CGRect(x: coverMargin, y: coverMargin, width: coverWidth, height: coverWidth)
+        albumCoverView.hxPicker_frame = CGRect(x: coverMargin, y: coverMargin, width: coverWidth, height: coverWidth)
         
         if viewController?.splitViewController != nil {
-            tickView.x = width - 12 - tickView.width
+            tickView.hxPicker_x = width - 12 - tickView.width
         }else {
-            tickView.x = width - 12 - tickView.width - UIDevice.rightMargin
+            tickView.hxPicker_x = width - 12 - tickView.width - UIDevice.rightMargin
         }
         tickView.centerY = height * 0.5
         
-        albumNameLb.x = albumCoverView.frame.maxX + 10
-        albumNameLb.size = CGSize(width: tickView.x - albumNameLb.x - 20, height: 16)
+        albumNameLb.hxPicker_x = albumCoverView.hxPicker_frame.maxX + 10
+        albumNameLb.size = CGSize(width: tickView.hxPicker_x - albumNameLb.hxPicker_x - 20, height: 16)
         
         if config.isShowPhotoCount {
             albumNameLb.centerY = height / 2 - albumNameLb.height / 2
             
-            photoCountLb.x = albumCoverView.frame.maxX + 10
-            photoCountLb.y = albumNameLb.frame.maxY + 5
-            photoCountLb.size = CGSize(width: width - photoCountLb.x - 20, height: 14)
+            photoCountLb.hxPicker_x = albumCoverView.hxPicker_frame.maxX + 10
+            photoCountLb.y = albumNameLb.hxPicker_frame.maxY + 5
+            photoCountLb.size = CGSize(width: width - photoCountLb.hxPicker_x - 20, height: 14)
         }else {
             albumNameLb.centerY = height / 2
         }
         
-        bottomLineView.frame = CGRect(x: coverMargin, y: height - 0.5, width: width - coverMargin * 2, height: 0.5)
+        bottomLineView.hxPicker_frame = CGRect(x: coverMargin, y: height - 0.5, width: width - coverMargin * 2, height: 0.5)
     }
     
     open override func layoutSubviews() {

--- a/Sources/HXPhotoPicker/Picker/View/Cell/Album/PhotoAlbumCollectionCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/Album/PhotoAlbumCollectionCell.swift
@@ -50,6 +50,11 @@ public class PhotoAlbumCollectionCell: UITableViewCell, UICollectionViewDataSour
         collectionView.register(PhotoAlbumCollectionViewCell.self)
         contentView.addSubview(collectionView)
         
+        if PhotoManager.isRTL {
+            collectionView.semanticContentAttribute = .forceRightToLeft
+        }else {
+            collectionView.semanticContentAttribute = .forceLeftToRight
+        }
         lineView = UIView()
         lineView.backgroundColor = UIColor.lightGray.withAlphaComponent(0.15)
         contentView.addSubview(lineView)
@@ -72,13 +77,13 @@ public class PhotoAlbumCollectionCell: UITableViewCell, UICollectionViewDataSour
     
     public override func layoutSubviews() {
         super.layoutSubviews()
-        collectionView.frame = contentView.bounds
+        collectionView.hxPicker_frame = contentView.bounds
         let count = rowCount - 1
         let margin: CGFloat = assetCollections.count > Int(rowCount) * 2 ? 5 : 0
         let itemWidth = (contentView.width - (30 + 12 * count)) / rowCount - margin
         let fontHeight = config.albumNameFont.lineHeight + config.photoCountFont.lineHeight + 8
         flowLayout.itemSize = .init(width: itemWidth, height: itemWidth + fontHeight)
-        lineView.frame = .init(x: 15, y: contentView.height - 0.5, width: contentView.width - 15, height: 0.5)
+        lineView.hxPicker_frame = .init(x: 15, y: contentView.height - 0.5, width: contentView.width - 15, height: 0.5)
     }
     
     func updateColors() {

--- a/Sources/HXPhotoPicker/Picker/View/Cell/Album/PhotoAlbumCollectionViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/Album/PhotoAlbumCollectionViewCell.swift
@@ -111,15 +111,15 @@ public class PhotoAlbumCollectionViewCell: UICollectionViewCell {
     public override func layoutSubviews() {
         super.layoutSubviews()
         imageView.frame = .init(x: 0, y: 0, width: contentView.width, height: contentView.width)
-        titleLb.x = 0
         titleLb.y = imageView.frame.maxY + 4
-        titleLb.width = contentView.width
         titleLb.height = titleLb.font.lineHeight
-        countLb.x = 0
+        titleLb.width = min(titleLb.textWidth, contentView.width)
+        titleLb.hxPicker_x = 0
         countLb.y = titleLb.frame.maxY + 2
-        countLb.width = contentView.width
         countLb.height = countLb.textHeight
-        selectedBgView.frame = imageView.bounds
+        countLb.width = countLb.textWidth
+        countLb.hxPicker_x = 0
+        selectedBgView.hxPicker_frame = imageView.bounds
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/HXPhotoPicker/Picker/View/Cell/Album/PhotoAlbumViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/Album/PhotoAlbumViewCell.swift
@@ -59,24 +59,25 @@ public class PhotoAlbumViewCell: UITableViewCell {
         if let imageSize = arrowView.image?.size {
             arrowView.size = imageSize
             arrowView.centerY = contentView.height / 2
-            arrowView.x = contentView.width - 15 - arrowView.width
+            arrowView.hxPicker_x = contentView.width - 15 - arrowView.width
+            arrowView.hxPicker_flip()
         }
         
         countLb.y = 0
         countLb.height = contentView.height
         countLb.width = countLb.textWidth
-        countLb.x = arrowView.x - 10 - countLb.width
+        countLb.hxPicker_x = arrowView.hxPicker_x - 10 - countLb.width
         
         if let image = iconView.image {
-            iconView.x = 15
             iconView.size = .init(width: image.width * 1.3, height: image.height * 1.3)
             iconView.centerY = height / 2
-            titleLb.frame = .init(x: 60, y: 0, width: countLb.x - 70, height: height)
+            iconView.hxPicker_x = 15
+            titleLb.hxPicker_frame = .init(x: 60, y: 0, width: countLb.hxPicker_x - 70, height: height)
         }else {
-            titleLb.frame = .init(x: 15, y: 0, width: countLb.x - 20, height: height)
+            titleLb.hxPicker_frame = .init(x: 15, y: 0, width: countLb.hxPicker_x - 20, height: height)
         }
         
-        lineView.frame = .init(x: titleLb.x, y: contentView.height - 0.5, width: contentView.width - 15, height: 0.5)
+        lineView.hxPicker_frame = .init(x: titleLb.hxPicker_x, y: contentView.height - 0.5, width: contentView.width - 15, height: 0.5)
     }
     
     func updateColors() {

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerSelectableViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerSelectableViewCell.swift
@@ -114,15 +114,15 @@ open class PhotoPickerSelectableViewCell: PhotoPickerViewCell {
         let topMargin = config.selectBoxTopMargin
         let rightMargin = config.selectBoxRightMargin
         let rect = CGRect(x: self.width - rightMargin - width, y: topMargin, width: width, height: height)
-        if selectControl.frame.equalTo(rect) {
+        if selectControl.hxPicker_frame.equalTo(rect) {
             return
         }
         if let photoAsset = photoAsset, photoAsset.isScrolling {
             let x = selectControl.x
-            selectControl.frame = rect
-            selectControl.x = x
+            selectControl.hxPicker_frame = rect
+            selectControl.hxPicker_x = x
         }else {
-            selectControl.frame = rect
+            selectControl.hxPicker_frame = rect
         }
     }
     

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerViewCell.swift
@@ -62,14 +62,14 @@ open class PhotoPickerViewCell: PhotoPickerBaseViewCell {
         
         selectMaskLayer = CALayer()
         selectMaskLayer.backgroundColor = UIColor.black.withAlphaComponent(0.6).cgColor
-        selectMaskLayer.frame = bounds
+        selectMaskLayer.hxPicker_frame = bounds
         selectMaskLayer.isHidden = true
         photoView.layer.addSublayer(selectMaskLayer)
         
         assetTypeLb = UILabel()
         assetTypeLb.font = .mediumPingFang(ofSize: 14)
         assetTypeLb.textColor = .white
-        assetTypeLb.textAlignment = .right
+        assetTypeLb.hxpicker_alignment = .right
         contentView.addSubview(assetTypeLb)
         
         assetTypeIcon = UIImageView(image: .imageResource.picker.photoList.cell.video.image)
@@ -203,10 +203,10 @@ open class PhotoPickerViewCell: PhotoPickerBaseViewCell {
     /// 布局
     open override func layoutView() {
         super.layoutView()
-        iCloudMarkView.x = width - iCloudMarkView.width - 5
+        iCloudMarkView.hxPicker_x = width - iCloudMarkView.width - 5
         iCloudMarkView.y = 5
         
-        assetTypeMaskView.frame = CGRect(x: 0, y: photoView.height - 25, width: width, height: 25)
+        assetTypeMaskView.hxPicker_frame = CGRect(x: 0, y: photoView.height - 25, width: width, height: 25)
         let assetTypeMakeFrame = CGRect(
             x: 0,
             y: -5,
@@ -226,25 +226,27 @@ open class PhotoPickerViewCell: PhotoPickerBaseViewCell {
         if updateFrame {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
-            assetTypeMaskLayer.frame = assetTypeMakeFrame
-            selectMaskLayer.frame = photoView.bounds
-            disableMaskLayer.frame = photoView.bounds
+            assetTypeMaskLayer.hxPicker_frame = assetTypeMakeFrame
+            selectMaskLayer.hxPicker_frame = photoView.bounds
+            disableMaskLayer.hxPicker_frame = photoView.bounds
             CATransaction.commit()
         }
-        assetTypeLb.frame = CGRect(x: 0, y: height - 19, width: width - 5, height: 18)
+        assetTypeLb.hxPicker_frame = CGRect(x: 0, y: height - 19, width: width - 5, height: 18)
         if let imageSize = assetTypeIcon.image?.size {
             assetTypeIcon.size = imageSize
         }
-        assetTypeIcon.x = 5
+        //备注：很多适配RTL的工程都会Hook调整alignment，因此该处根据当前的alignment来调整图标的位置（避免遮挡）
+        let isAssetTypeLbInRight = assetTypeLb.hxpicker_alignment == .right
+        assetTypeIcon.hxPicker_x = isAssetTypeLbInRight ? 5 : (width - assetTypeIcon.width - 5)
         assetTypeIcon.y = height - assetTypeIcon.height - 5
         assetTypeLb.centerY = assetTypeIcon.centerY
         if let imageSize = assetEditMarkIcon.image?.size {
             assetEditMarkIcon.size = imageSize
         }
-        assetEditMarkIcon.x = 5
+        assetEditMarkIcon.hxPicker_x = 5
         assetEditMarkIcon.y = height - assetEditMarkIcon.height - 5
         
-        loaddingView.frame = bounds
+        loaddingView.hxPicker_frame = bounds
     }
     
     /// 设置高亮时的遮罩

--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerWeChatViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerWeChatViewCell.swift
@@ -14,7 +14,7 @@ open class PhotoPickerWeChatViewCell: PhotoPickerSelectableViewCell {
     open override func initView() {
         super.initView()
         titleLb = UILabel()
-        titleLb.textAlignment = .center
+        titleLb.hxpicker_alignment = .center
         titleLb.textColor = .white
         titleLb.font = .semiboldPingFang(ofSize: 15)
         titleLb.isHidden = true
@@ -32,6 +32,6 @@ open class PhotoPickerWeChatViewCell: PhotoPickerSelectableViewCell {
     
     open override func layoutView() {
         super.layoutView()
-        titleLb.x = 10
+        titleLb.hxPicker_x = 10
     }
 }

--- a/Sources/HXPhotoPicker/Picker/View/ToolBar/PhotoPermissionPromptView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/ToolBar/PhotoPermissionPromptView.swift
@@ -40,6 +40,9 @@ class PhotoPermissionPromptView: UIView {
         if let imageSize = promptArrow.image?.size {
             promptArrow.size = imageSize
         }
+        if PhotoManager.isRTL {
+            promptArrow.hxPicker_flip()
+        }
         addSubview(promptArrow)
         
         addGestureRecognizer(
@@ -87,18 +90,18 @@ class PhotoPermissionPromptView: UIView {
         let viewHeight = height
         let leftMargin = self.leftMargin
         if leftMargin > 0 {
-            promptIcon.x = leftMargin
+            promptIcon.hxPicker_x = leftMargin
         }else {
-            promptIcon.x = 12
+            promptIcon.hxPicker_x = 12
         }
         promptIcon.centerY = viewHeight * 0.5
         if UIDevice.rightMargin > 0 {
-            promptArrow.x = width - promptArrow.width - UIDevice.rightMargin
+            promptArrow.hxPicker_x = width - promptArrow.width - UIDevice.rightMargin
         }else {
-            promptArrow.x = width - 12 - promptArrow.width
+            promptArrow.hxPicker_x = width - 12 - promptArrow.width
         }
-        promptLb.x = promptIcon.frame.maxX + 12
-        promptLb.width = promptArrow.x - promptLb.x - 12
+        promptLb.hxPicker_x = promptIcon.hxPicker_maxX + 12
+        promptLb.width = promptArrow.hxPicker_x - promptLb.hxPicker_x - 12
         promptLb.centerY = viewHeight * 0.5
         promptArrow.centerY = viewHeight * 0.5
     }

--- a/Sources/HXPhotoPicker/Picker/View/ToolBar/PhotoToolBarView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/ToolBar/PhotoToolBarView.swift
@@ -470,18 +470,18 @@ public class PhotoToolBarView: UIToolbar, PhotoToolBar {
                 contentView.y = height - contentView.height
             }
             if leftMargin > 0 {
-                previewBtn.x = leftMargin
+                previewBtn.hxPicker_x = leftMargin
             }else {
-                previewBtn.x = 12
+                previewBtn.hxPicker_x = 12
             }
             updateFinishButtonFrame()
             updateOriginalViewFrame()
         }else if type == .preview {
             #if HXPICKER_ENABLE_EDITOR
             if UIDevice.leftMargin > 0 {
-                editBtn.x = UIDevice.leftMargin
+                editBtn.hxPicker_x = UIDevice.leftMargin
             }else {
-                editBtn.x = 12
+                editBtn.hxPicker_x = 12
             }
             #endif
             if isShowPreviewList {
@@ -798,6 +798,9 @@ extension PhotoToolBarView {
             originalView.frame = CGRect(x: 0, y: 0, width: originalTitleLb.frame.maxX, height: 50)
         }
         originalView.centerX = width / 2
+        if PhotoManager.isRTL {
+            return
+        }
         let originalMinX: CGFloat
         if type == .picker {
             originalMinX = previewBtn.frame.maxX + 2
@@ -826,18 +829,20 @@ extension PhotoToolBarView {
             ),
             height: 50
         )
-        let leftMargin: CGFloat
-        if type == .picker {
-            leftMargin = previewBtn.frame.maxX
-        }else {
-            #if HXPICKER_ENABLE_EDITOR
-            leftMargin = editBtn.frame.maxX
-            #else
-            leftMargin = 10
-            #endif
-        }
-        if originalTitleLb.width > width - leftMargin - finishBtn.width - 12 {
-            originalTitleLb.width = width - leftMargin - finishBtn.width - 12
+        if !PhotoManager.isRTL {
+            let leftMargin: CGFloat
+            if type == .picker {
+                leftMargin = previewBtn.frame.maxX
+            }else {
+                #if HXPICKER_ENABLE_EDITOR
+                leftMargin = editBtn.frame.maxX
+                #else
+                leftMargin = 10
+                #endif
+            }
+            if originalTitleLb.width > width - leftMargin - finishBtn.width - 12 {
+                originalTitleLb.width = width - leftMargin - finishBtn.width - 12
+            }
         }
         originalBox.centerY = originalTitleLb.height * 0.5
         originalLoadingView.centerY = originalView.height * 0.5
@@ -890,9 +895,9 @@ extension PhotoToolBarView {
         }
         finishBtn.size = .init(width: finishWidth, height: 33)
         if UIDevice.rightMargin > 0 {
-            finishBtn.x = width - UIDevice.rightMargin - finishWidth
+            finishBtn.hxPicker_x = width - UIDevice.rightMargin - finishWidth
         }else {
-            finishBtn.x = width - finishWidth - 12
+            finishBtn.hxPicker_x = width - finishWidth - 12
         }
         finishBtn.centerY = 25
     }


### PR DESCRIPTION
**1、概要**

我们的HXPhotoPicker是按照frame布局的，因此在阿语环境下避免不了有些兼容问题，我对其做了兼容修改，你看下要不要合并（Issues上看到也有人反馈阿语的兼容问题）

**2、主要调整：**

1、新增了2个分类扩展：对UIView、CALayer的frame，x等属性做了支持RTL
2、新增了UILabel的alignment，支持RTL

备注：核心就是将视图布局的xxx.frame 改成支持RTL的hxPicker_frame，x 改成 hxPicker_x（坐标内部会做RTL兼容）

**3、修复3处阿语不兼容：**

1、相册选择页面：视频时长与视频图标UI重叠
2、点击顶部-相册分类列表：打勾以及相册名字与数量UI重写错误
3、照片预览：按住图片-拖动，图片会被镜像，释放之后又正确显示


**4、UI预览**
<div style="width: 600px; /* 确保宽度足够容纳三张图片 */ overflow: auto; /* 防止内容溢出 */">
    <img src="https://github.com/user-attachments/assets/21aa99f9-81b8-4723-bc10-8564be2a5222" width="200" style="display: inline-block; margin: 0; padding: 0;">
    <img src="https://github.com/user-attachments/assets/73ddd250-8a6f-4ba1-856f-4bc49717c8c2" width="200" style="display: inline-block; margin: 0; padding: 0;">
    <img src="https://github.com/user-attachments/assets/4e59c39f-030c-4d7b-988f-5eb732032df8" width="200" style="display: inline-block; margin: 0; padding: 0;">
</div>