### PR TITLE
修复resultHasChanges使用insertedObjects/removedObjects判断不准确的问题

### DIFF
--- a/Sources/HXPhotoPicker/Picker/Controller/Photo/PhotoPickerController+PHPhotoLibrary.swift
+++ b/Sources/HXPhotoPicker/Picker/Controller/Photo/PhotoPickerController+PHPhotoLibrary.swift
@@ -68,9 +68,6 @@ extension PhotoPickerController: PHPhotoLibraryChangeObserver {
             return false
         }
         if let changeResult  = changeInstance.changeDetails(for: result) {
-            if changeResult.insertedObjects.isEmpty, changeResult.removedObjects.isEmpty {
-                return false
-            }
             let fetchAssetCollection = fetchData.config.fetchAssetCollection
             fetchAssetCollection.enumerateAllAlbums(options: nil) { collection, _, stop in
                 if collection.localIdentifier == assetCollection.collection?.localIdentifier {


### PR DESCRIPTION
<img width="881" alt="图片" src="https://github.com/user-attachments/assets/fe9fe58e-f9db-4bd8-86d2-e2d271bf14cf" />
<img width="993" alt="图片" src="https://github.com/user-attachments/assets/71ba36a6-33d4-4287-b0d7-fff6a81446de" />

iOS 18.5实测，在LimitedLibraryPicker中，不管有没有改变，hasIncrementalChanges返回的是false

另外，这里还存在一个问题，比如说相册中有2张照片，LimitedLibraryPicker时选择另外2张，数量是不变的，但是照片却发生了变化

所以这里把insertedObjects/removedObjects去掉保险些
