### PR TITLE
Fix: Resolve Xcode 26 build error causing iOS < 17 crash

### DIFF
--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIImage.swift
@@ -404,8 +404,17 @@ extension UIImage {
             kCGImageSourceShouldCacheImmediately: false
         ]
         if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
-            decodingOptions[kCGImageSourceDecodeRequest] = kCGImageSourceDecodeToHDR
-        }
+			let handle = dlopen("/System/Library/Frameworks/ImageIO.framework/ImageIO", RTLD_LAZY)
+			defer { if handle != nil { dlclose(handle) } }
+
+			if let handle = handle,
+			   let keyPtr = dlsym(handle, "kCGImageSourceDecodeRequest"),
+			   let valPtr = dlsym(handle, "kCGImageSourceDecodeToHDR") {
+				let key = unsafeBitCast(keyPtr, to: CFString.self)
+				let value = unsafeBitCast(valPtr, to: CFTypeRef.self)
+				decodingOptions[key] = value
+			}
+		}
         guard let imageRef = CGImageSourceCreateImageAtIndex(sourceRef, 0, decodingOptions as CFDictionary) else {
             return nil
         }


### PR DESCRIPTION
# 问题描述

使用Xcode26，在 iOS < 17 运行时，因直接引用 `kCGImageSourceDecodeRequest`，会导致 dyld 加载失败崩溃（找不到符号）。

# 解决方案

- 用 `dlsym` 动态查找符号，避免低系统版本的崩溃。
- 保持 API 兼容和功能不变。

# 具体改动

## 源代码

```swift
if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
    decodingOptions[kCGImageSourceDecodeRequest] = kCGImageSourceDecodeToHDR
}
```

## 新代码

```swift
if #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) {
    let handle = dlopen("/System/Library/Frameworks/ImageIO.framework/ImageIO", RTLD_LAZY)
    defer { if handle != nil { dlclose(handle) } }

    if let handle = handle,
        let keyPtr = dlsym(handle, "kCGImageSourceDecodeRequest"),
        let valPtr = dlsym(handle, "kCGImageSourceDecodeToHDR") {
        let key = unsafeBitCast(keyPtr, to: CFString.self)
        let value = unsafeBitCast(valPtr, to: CFTypeRef.self)
        decodingOptions[key] = value
    }
}
```