### PR TITLE
5.0.3版本加入了列表预览LivePhoto，若相册有较多的LivePhoto会引起列表滑动卡顿掉帧

### DIFF
--- a/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerSelectableViewCell.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Cell/PhotoPickerSelectableViewCell.swift
@@ -252,9 +252,9 @@ open class PhotoPickerSelectableViewCell: PhotoPickerViewCell {
         livePhotoView.playbackGestureRecognizer.isEnabled = false
         livePhotoView.delegate = self
         livePhotoView.isHidden = true
-        contentView.insertSubview(livePhotoView, aboveSubview: selectControl)
+        contentView.insertSubview(livePhotoView, aboveSubview: photoView)
         self.livePhotoView = livePhotoView
-        self.setNeedsLayout()
+        livePhotoView.frame = bounds
     }
     
     open func createLivePhotoButtonIfNeeded() {
@@ -277,7 +277,7 @@ open class PhotoPickerSelectableViewCell: PhotoPickerViewCell {
         livePhotoButton.isHidden = true
         contentView.addSubview(livePhotoButton)
         self.livePhotoButton = livePhotoButton
-        self.setNeedsLayout()
+        setupAssetTypeFrame()
     }
     
     func updateSelectControlSize() {
@@ -304,7 +304,7 @@ open class PhotoPickerSelectableViewCell: PhotoPickerViewCell {
                 requestLivePhoto(isPlay: !livePhotoButton.isSelected)
             }else {
                 if livePhotoButton.isSelected {
-                    removeLivePhotoView()
+                    livePhotoView.stopPlayback()
                 }else {
                     livePhotoView.startPlayback(with: .full)
                 }


### PR DESCRIPTION
优化PhotoPickerSelectableViewCell，当livePhoto需要播放时创建，播放完成移除，避免每次创建cell时创建livePhotoView导致卡顿掉帧，同时减少内存占用（PHLivePhotoView内部有个AVPlayer）

备注：因相册具有隐私性，不便上传掉帧的复现视频，可通过5.0.3的demo复现，前提是相册有较多的LivePhoto