### PR TITLE
fix[选择器]: 照片列表的缩略图请求失败时出现的复用问题

### DIFF
--- a/Sources/HXPhotoPicker/Core/Extension/Core+UIImageView.swift
+++ b/Sources/HXPhotoPicker/Core/Extension/Core+UIImageView.swift
@@ -10,18 +10,16 @@ import UIKit
 extension UIImageView {
     
     func setImage(_ image: UIImage?, duration: CFTimeInterval = 0.2, animated: Bool = true) {
-        if let image = image {
-            if animated {
-                UIView.transition(
-                    with: self,
-                    duration: duration,
-                    options: [.transitionCrossDissolve, .curveEaseInOut, .allowUserInteraction]
-                ) {
-                    self.image = image
-                }
-            }else {
+        if let image, animated {
+            UIView.transition(
+                with: self,
+                duration: duration,
+                options: [.transitionCrossDissolve, .curveEaseInOut, .allowUserInteraction]
+            ) {
                 self.image = image
             }
+        } else {
+            self.image = image
         }
     }
 }

--- a/Sources/HXPhotoPicker/Picker/View/PhotoThumbnailView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/PhotoThumbnailView.swift
@@ -142,18 +142,18 @@ open class PhotoThumbnailView: UIView {
                 guard let self = self else { return }
                 if let info = info, info.isCancel { return }
                 if self.photoAsset == photoAsset {
-                    if let image = image {
-                        self.requestCompletion(image)
-                        if !AssetManager.assetIsDegraded(for: info) {
-                            self.requestID = nil
-                            if PhotoManager.shared.thumbnailLoadMode == .complete {
-                                self.loadCompletion = true
-                            }
+                    self.requestCompletion(image)
+                    if image != nil, !AssetManager.assetIsDegraded(for: info) {
+                        self.requestID = nil
+                        if PhotoManager.shared.thumbnailLoadMode == .complete {
+                            self.loadCompletion = true
                         }
                     }
                     if PhotoManager.shared.thumbnailLoadMode == .complete {
                         self.completeLoading = false
                     }
+                } else {
+                    self.requestCompletion(nil)
                 }
                 completion?(image, photoAsset)
             }


### PR DESCRIPTION
修复 #826  
> 选择器中，照片缩略图列表在滚动时，如果资源没有下载到本地，例如下载失败，缩略图出现复用问题