### PR TITLE
当相册权限设置为受限访问，且没有选择任何照片的情况下，AlbumGlassTitleView会产生数据越界的问题

### DIFF
--- a/Sources/HXPhotoPicker/Picker/View/Album/AlbumGlassTitleView.swift
+++ b/Sources/HXPhotoPicker/Picker/View/Album/AlbumGlassTitleView.swift
@@ -106,17 +106,15 @@ public class AlbumGlassTitleView: UIView, PhotoPickerNavigationTitle {
             let id = UIAction.Identifier("album_\(index)")
             let action = UIAction(title: albumName, identifier: id, state: collection.isSelected ? .on: .off, handler: { [weak self] action in
                 guard let self else { return }
-                if let idString = action.identifier.rawValue.split(separator: "_").last,
-                   let idx = Int(idString), idx < self.assetCollections.count {
-                    let assetCollection = self.assetCollections[idx]
+                if index < self.assetCollections.count {
+                    let assetCollection = self.assetCollections[index]
                     self.selectHandler?(assetCollection)
                 }
             })
             _ = collection.requestCoverImage(targetWidth: 24) { [weak self] in
                 guard let self = self else { return }
                 if let info = $2, info.isCancel { return }
-                if let index = self.assetCollections.firstIndex(of: $1), index < self.actions.count,
-                   let image = $0?.scaleToFillSize(size: CGSize(width: 24, height: 24), mode: .center, scale: UIScreen.main.scale) {
+                if index < self.actions.count, let image = $0?.scaleToFillSize(size: CGSize(width: 24, height: 24), mode: .center, scale: UIScreen.main.scale) {
                     let action = self.actions[index]
                     action.image = image
                     if let old = self.button.menu {


### PR DESCRIPTION
当相册权限设置为受限访问，且没有选择任何照片的情况下，AlbumGlassTitleView会产生数据越界的问题，另外CoverImage按照尺寸裁剪，避免图片大小不一看起来比较乱